### PR TITLE
Have entrypoint update playit to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,10 @@ USER root
 WORKDIR /var/app
 
 RUN apt update && \
-    apt upgrade && \
     apt install -y curl && \
-    apt install -y gnupg2 && \
-    apt-key del '16AC CC32 BD41 5DCC 6F00  D548 DA6C D75E C283 9680' && \
-    apt update && \
-    curl -SsL https://playit-cloud.github.io/ppa/key.gpg | gpg --dearmor | tee /etc/apt/trusted.gpg.d/playit.gpg >/dev/null && \
+    apt install -y gnupg2
+
+RUN curl -SsL https://playit-cloud.github.io/ppa/key.gpg | gpg --dearmor | tee /etc/apt/trusted.gpg.d/playit.gpg >/dev/null && \
     echo "deb [signed-by=/etc/apt/trusted.gpg.d/playit.gpg] https://playit-cloud.github.io/ppa/data ./" | tee /etc/apt/sources.list.d/playit-cloud.list && \
     apt update && \
     apt install -y playit
@@ -31,4 +29,4 @@ COPY app/frontend /var/app/frontend
 RUN cd /var/app/frontend && npm install && npm run build
 RUN cd /var/app/backend && npm install
 
-ENTRYPOINT node /var/app/backend/app.js
+ENTRYPOINT bash /var/app/backend/entrypoint.sh

--- a/app/backend/entrypoint.sh
+++ b/app/backend/entrypoint.sh
@@ -1,0 +1,5 @@
+# make sure we're running latest version of the playit program
+apt update
+apt install -y playit
+
+node /var/app/backend/app.js


### PR DESCRIPTION
Playit program has been upgraded to 0.16.3. Users running the current docker image are unable to use our new regions.

Rather than releasing a new docker image for each playit release entrypoint upgrades the playit program before running the backend.